### PR TITLE
Fix incorrect namespace for configured and placed features.

### DIFF
--- a/src/main/java/io/github/saltyseadoggo/blazingdepths/features/NetherDuneFeature.java
+++ b/src/main/java/io/github/saltyseadoggo/blazingdepths/features/NetherDuneFeature.java
@@ -42,10 +42,12 @@ public class NetherDuneFeature extends Feature<DuneFeatureConfig> {
         //Get the sand and sandstone blocks from the config
         BlockState surfaceBlock = config.surfaceBlock().getBlockState(featureContext.getRandom(), pos);
         BlockState underBlock = config.underBlock().getBlockState(featureContext.getRandom(), pos);
+        //Grab the random instance from a feature context
+        Random random = featureContext.getRandom();
         //Choose a random height, length (the longer side) and width (the shorter side) for this dune from the config.
-        int duneHeight = config.height().get(new Random());
-        int duneLength = config.length().get(new Random());
-        int duneWidth = config.width().get(new Random());
+        int duneHeight = config.height().get(random);
+        int duneLength = config.length().get(random);
+        int duneWidth = config.width().get(random);
 
         //If the feature origin isn't on top of seared sand, cancel generation.
         //This stops dunes from generating on top of Nether fortresses and the like, which looks terrible.

--- a/src/main/java/io/github/saltyseadoggo/blazingdepths/init/BlazingDepthsFeatures.java
+++ b/src/main/java/io/github/saltyseadoggo/blazingdepths/init/BlazingDepthsFeatures.java
@@ -1,5 +1,6 @@
 package io.github.saltyseadoggo.blazingdepths.init;
 
+import io.github.saltyseadoggo.blazingdepths.BlazingDepths;
 import io.github.saltyseadoggo.blazingdepths.features.*;
 import io.github.saltyseadoggo.blazingdepths.features.config.BigRootFeatureConfig;
 import io.github.saltyseadoggo.blazingdepths.features.config.DuneFeatureConfig;
@@ -82,12 +83,13 @@ public class BlazingDepthsFeatures {
         return Registry.register(Registry.FEATURE, name, feature);
     }
     //Configured feature registering method adapted from ConfiguredFeatures.class
-    public static <FC extends FeatureConfig, F extends Feature<FC>> RegistryEntry<ConfiguredFeature<FC, ?>> registerCFeature(String id, F feature, FC config) {
-        return BuiltinRegistries.method_40360(BuiltinRegistries.CONFIGURED_FEATURE, id, new ConfiguredFeature(feature, config));
+    public static <FC extends FeatureConfig, F extends Feature<FC>, C extends ConfiguredFeature<FC, ?>> RegistryEntry<C> registerCFeature(String id, F feature, FC config) {
+        return (RegistryEntry<C>) BuiltinRegistries.add(BuiltinRegistries.CONFIGURED_FEATURE, BlazingDepths.makeIdentifier(id), new ConfiguredFeature<FC, F>(feature, config));
     }
+    
     //Placed feature registering methods adapted from PlacedFeatures.class
     public static RegistryEntry<PlacedFeature> registerPFeature(String id, RegistryEntry<? extends ConfiguredFeature<?, ?>> registryEntry, List<PlacementModifier> modifiers) {
-        return BuiltinRegistries.add(BuiltinRegistries.PLACED_FEATURE, id, new PlacedFeature(RegistryEntry.upcast(registryEntry), List.copyOf(modifiers)));
+        return BuiltinRegistries.add(BuiltinRegistries.PLACED_FEATURE, BlazingDepths.makeIdentifier(id), new PlacedFeature(RegistryEntry.upcast(registryEntry), List.copyOf(modifiers)));
     }
     public static RegistryEntry<PlacedFeature> registerPFeature(String id, RegistryEntry<? extends ConfiguredFeature<?, ?>> registryEntry, PlacementModifier... modifiers) {
         return registerPFeature(id, registryEntry, List.of(modifiers));


### PR DESCRIPTION
The configured and placed features were registered under Minecraft's namespace and not the mod's id. For example, it was `minecraft:nether_dune_feature` and not `blazing_depths:nether_dune_feature`